### PR TITLE
Fix poll repetition

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 import logging
 from telegram.ext import Application, CommandHandler, MessageHandler, filters, PollAnswerHandler
 from config import TOKEN, GALACTUS_PATTERN
-from utils.files import load_chat_ids, load_last_updated_date
+from utils.files import load_chat_ids, load_last_updated_date, load_cards_sent
 from handlers.polls import registrar_resposta_enquete
 from handlers.commands import start_command, decks_command, spotlight_command, ranking_command, card_command, atualizar_lista_de_cartas_command, ranking_command
 from handlers.events import welcome_user, user_left_group
@@ -27,8 +27,10 @@ def main():
     init_data_directory()
     load_last_updated_date()
     load_chat_ids()
+    cards_sent = load_cards_sent()
 
     app = Application.builder().token(TOKEN).build()
+    app.bot_data["cards_sent"] = cards_sent
 
     # comandos
     app.add_handler(CommandHandler("start", start_command))

--- a/config.py
+++ b/config.py
@@ -41,6 +41,7 @@ UPDATE_FILE_PATH = DATA_DIR / "last_update.txt"
 CHAT_IDS_FILE_PATH = DATA_DIR / "chat_ids.json"
 USER_IDS_FILE_PATH = DATA_DIR / "user_ids.json"
 RANK_FILE = DATA_DIR / "card_votes.json"
+CARDS_SENT_FILE = DATA_DIR / "cards_sent.json"
 
 # Constantes
 COOLDOWN_TIME = 60

--- a/handlers/polls.py
+++ b/handlers/polls.py
@@ -24,6 +24,8 @@ def pergunta_com_chat(carta: str, chat_id: int) -> str:
 
 async def enviar_enquete_carta_unica(context: CallbackContext):
     chat_id = context.job.data.get("chat_id") if context.job else GALACTUS_CHAT_ID
+    if str(chat_id) != str(GALACTUS_CHAT_ID):
+        return
     carta = pick_card_without_repetition(context.bot_data, CARDS_NAMES)
 
     loop = asyncio.get_running_loop()

--- a/jobs/scheduler.py
+++ b/jobs/scheduler.py
@@ -3,6 +3,7 @@ from telegram.ext import JobQueue, CallbackContext
 from datetime import time as dt_time 
 from zoneinfo import ZoneInfo         
 from utils.files import load_chat_ids
+from config import GALACTUS_CHAT_ID
 from utils.helpers import send_cosmic_roulette
 from handlers.polls import enviar_enquete_carta_unica
 
@@ -54,5 +55,6 @@ def schedule_link_jobs_for_all_chats(job_queue: JobQueue):
                 name=roulette_name,
             )
 
-        schedule_polls_for_chat(job_queue, chat_id) 
+        if str(chat_id) == str(GALACTUS_CHAT_ID):
+            schedule_polls_for_chat(job_queue, chat_id)
 

--- a/utils/cards.py
+++ b/utils/cards.py
@@ -12,6 +12,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
+from utils.files import save_cards_sent
 
 logger = logging.getLogger(__name__)
 
@@ -151,13 +152,15 @@ def pick_card_without_repetition(bot_data: dict, card_names: list[str]) -> str:
     Escolhe uma carta aleatória. Garante que cada carta seja usada no máximo 1× por dia.
     Reinicia o ciclo se esgotar todas.
     """
-    used_today: set[str] = bot_data.setdefault("cards_sent", {}).setdefault(_today_key(), set())
+    data = bot_data.setdefault("cards_sent", {})
+    used_today: set[str] = data.setdefault(_today_key(), set())
     remaining = [c for c in card_names if c not in used_today]
     if not remaining:                       
         used_today.clear()
         remaining = card_names
     card = random.choice(remaining)
     used_today.add(card)
+    save_cards_sent(data)
     return card
 
 _EXCLUDED = {"none", "unreleased"}

--- a/utils/files.py
+++ b/utils/files.py
@@ -1,6 +1,6 @@
 import os
 import json
-from config import CHAT_IDS_FILE_PATH, UPDATE_FILE_PATH, logger
+from config import CHAT_IDS_FILE_PATH, UPDATE_FILE_PATH, CARDS_SENT_FILE, logger
 
 def load_chat_ids():
     if not os.path.exists(CHAT_IDS_FILE_PATH):
@@ -47,4 +47,25 @@ def save_last_updated_date(date):
             logger.info(f"Data de atualização salva: {last_updated_date}")
     except Exception as e:
         logger.error(f"Erro ao salvar data de atualização: {e}")
+
+
+def load_cards_sent():
+    if not os.path.exists(CARDS_SENT_FILE):
+        return {}
+    try:
+        with open(CARDS_SENT_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return {k: set(v) for k, v in data.items()}
+    except Exception as e:
+        logger.error(f"Erro ao carregar cards enviados: {e}")
+        return {}
+
+
+def save_cards_sent(cards_sent: dict):
+    try:
+        serializable = {k: list(v) for k, v in cards_sent.items()}
+        with open(CARDS_SENT_FILE, "w", encoding="utf-8") as f:
+            json.dump(serializable, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logger.error(f"Erro ao salvar cards enviados: {e}")
 


### PR DESCRIPTION
## Summary
- persist card usage with cards_sent.json so polls don't repeat the same card after restarts
- only schedule and run polls for the GALACTUS_CHAT_ID

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684027907ec08325a3940344ce2e37f3