### PR TITLE
Fix logger variable typos

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -88,7 +88,7 @@ async def card_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await context.bot.send_photo(message.chat_id, img, caption=cap, parse_mode="Markdown")
                 return
             except Exception as e:
-                log.error("Falha snap-card: %s", e)
+                logger.error("Falha snap-card: %s", e)
 
         # fallback clássico (sem KeyError!)
         msg = result if isinstance(result, str) else result.get("error", "Carta não encontrada.")

--- a/utils/decks.py
+++ b/utils/decks.py
@@ -101,7 +101,7 @@ def fetch_updated_date_fast() -> Optional[str]:
         resp = requests.get(DECK_LIST_URL, headers=UA, timeout=8)
         resp.raise_for_status()
     except Exception as exc:
-        log.error("GET %s falhou: %s", DECK_LIST_URL, exc)
+        logger.error("GET %s falhou: %s", DECK_LIST_URL, exc)
         return None
 
     date_html = _extract_date_from_html(resp.text)


### PR DESCRIPTION
## Summary
- fix typo in log messages

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684024d30e3c8325a09965d025fbb655