### PR TITLE
Fix poll persistence and cleanup imports

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -1,5 +1,5 @@
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import CallbackContext, ContextTypes ,CommandHandler
+from telegram.ext import CallbackContext, ContextTypes
 from utils.cards import get_card_info, format_card_message, update_card_list
 from utils.decks import get_decks_keyboard
 from utils.files import load_chat_ids, save_chat_ids, load_last_updated_date

--- a/handlers/polls.py
+++ b/handlers/polls.py
@@ -1,13 +1,6 @@
 import asyncio
-import random
+import time
 from telegram import Update
-from telegram.ext import CallbackContext, CommandHandler
-from utils.ranking import calculate_top_bottom, vote_stats
-from telegram import Update, Poll
-from telegram.ext import (
-    CallbackContext,
-    PollAnswerHandler,
-)
 from telegram.ext import CallbackContext
 from config import GALACTUS_CHAT_ID
 from utils.cards import CARDS_NAMES, pick_card_without_repetition, get_card_info, format_card_message
@@ -18,9 +11,8 @@ VOTE_OPTIONS = ["🏆 Meta", "✅ Boa", "🤔 Situacional", "⚠️ Ruim", "🚫
 
 _OPTION_TO_SCORE = {0: 2, 1: 1, 2: 0, 3: -1, 4: -2}
 
-def question_with_chat(card: str, chat_id: int) -> str:
-    suffix = f" —{str(chat_id)[-3:]}"
-    return f'O que você acha da carta "{card}"?{suffix}'
+def question(card: str) -> str:
+    return f'O que você acha da carta "{card}"?'
 
 async def send_single_card_poll(context: CallbackContext):
     chat_id = context.job.data.get("chat_id") if context.job else GALACTUS_CHAT_ID
@@ -51,7 +43,7 @@ async def send_single_card_poll(context: CallbackContext):
             disable_web_page_preview=True,
         )
     
-    pergunta = question_with_chat(carta, chat_id)
+    pergunta = question(carta)
 
     poll = await context.bot.send_poll(
         chat_id,
@@ -61,7 +53,9 @@ async def send_single_card_poll(context: CallbackContext):
         allows_multiple_answers=False,
     )
     context.bot_data.setdefault("active_polls", {})[poll.poll.id] = {
-        "carta": carta
+        "carta": carta,
+        "chat_id": chat_id,
+        "timestamp": int(time.time()),
     }
     save_active_polls(context.bot_data["active_polls"])
 

--- a/utils/files.py
+++ b/utils/files.py
@@ -89,6 +89,7 @@ def load_active_polls() -> dict:
 
 def save_active_polls(data: dict) -> None:
     try:
+        ACTIVE_POLLS_FILE.parent.mkdir(parents=True, exist_ok=True)
         with open(ACTIVE_POLLS_FILE, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
     except Exception as e:


### PR DESCRIPTION
## Summary
- ensure active polls file directory exists
- store chat id and timestamp for polls
- remove chat suffix from poll question
- tidy unused imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68418c4420b08325b56ee47dd9ce3433